### PR TITLE
Make standardScreenHeight typing optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
 declare function RFPercentage(percent: number): number;
-declare function RFValue(value: number, standardScreenHeight: number): number;
+declare function RFValue(value: number, standardScreenHeight?: number): number;
 
 export { RFPercentage, RFValue };


### PR DESCRIPTION
Small update to the type definitions file.

TypeScript throws an error if a value is not provided for `standardScreenHeight` even though it's [optional](https://github.com/heyman333/react-native-responsive-fontSize/blob/4440fa5bf67f6ea4f9025566d8f1ccce185558b3/index.js#L19).

```tsx
fontSize: RFValue(16)
          ^^^^^^^^^^^
Expected 2 arguments, but got 1.ts(2554)
An argument for 'standardScreenHeight' was not provided.
```
