### PR TITLE
Included New Offset Value Based On IphoneX

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,15 @@
-import { isIphoneX } from "react-native-iphone-x-helper";
+import { getBottomSpace, isIphoneX } from "react-native-iphone-x-helper";
 import { Platform, StatusBar, Dimensions } from "react-native";
 
 export function RFPercentage(percent) {
   const { height, width } = Dimensions.get("window");
   const standardLength = width > height ? width : height;
   const offset =
-    width > height ? 0 : Platform.OS === "ios" ? 78 : StatusBar.currentHeight; // iPhone X style SafeAreaView size in portrait
+    width > height
+      ? 0
+      : Platform.OS === "ios"
+      ? 78 + getBottomSpace()
+      : StatusBar.currentHeight; // iPhone X style SafeAreaView size in portrait
 
   const deviceHeight =
     isIphoneX() || Platform.OS === "android"
@@ -21,7 +25,11 @@ export function RFValue(fontSize, standardScreenHeight = 680) {
   const { height, width } = Dimensions.get("window");
   const standardLength = width > height ? width : height;
   const offset =
-    width > height ? 0 : Platform.OS === "ios" ? 78 : StatusBar.currentHeight; // iPhone X style SafeAreaView size in portrait
+    width > height
+      ? 0
+      : Platform.OS === "ios"
+      ? 78 + getBottomSpace()
+      : StatusBar.currentHeight; // iPhone X style SafeAreaView size in portrait
 
   const deviceHeight =
     isIphoneX() || Platform.OS === "android"


### PR DESCRIPTION
Hello guys, I encountered a problem when I was using the lib.
I was using as standardScreenHeight the height of the first generation IphoneSE, and when my text was rendered on the screen, in the Iphone SE and in the Android, it was identical, however when I ran it on an iphone X and compared to the Iphone SE it was a little disproportionate. I assume it is the size of the bottom of the IphoneX, which is not being calculated in the offset, so I included it and it was identical in all. Could you verify this change?